### PR TITLE
Don't ignore "fill" for polarized maps in unsolve_map

### DIFF
--- a/python/qmap_class.py
+++ b/python/qmap_class.py
@@ -1303,6 +1303,7 @@ class QMap(QPoint):
             rtri, ctri = np.triu_indices(nmap)
             idx[rtri, ctri] = idx[ctri, rtri] = np.arange(nproj)
             map_in[:] = np.einsum('ij...,j...->i...', proj[idx], map_in)
+            map_in[:, ~mask] = fill
 
         # return
         ret = (map_in,) + (proj,) * return_proj + (mask,) * return_mask


### PR DESCRIPTION
In unsolve_map, use "fill" option for polarized maps in addition to unpolarized maps.