### PR TITLE
Use non-deprecated np.int_ for ctypes long* arrays

### DIFF
--- a/python/_libqpoint.py
+++ b/python/_libqpoint.py
@@ -30,10 +30,10 @@ wvec3_t_p = NDP(np.double, ndim=2, flags=['A','C','W'])
 arr = NDP(np.double, ndim=1, flags=['A','C'])
 arrf = NDP(np.uint8, ndim=1, flags=['A','C'])
 warr = NDP(np.double, ndim=1, flags=['A','C','W'])
-warri = NDP(np.int, ndim=1, flags=['A','C','W'])
+warri = NDP(np.int_, ndim=1, flags=['A','C','W'])
 
 arr2 = NDP(np.uintp, ndim=1, flags=['A','C'])
-larr = NDP(np.long, ndim=1, flags=['A','C'])
+larr = NDP(np.int_, ndim=1, flags=['A','C'])
 
 QP_DO_ALWAYS = ct.c_int.in_dll(libqp, "QP_DO_ALWAYS").value
 QP_DO_ONCE = ct.c_int.in_dll(libqp, "QP_DO_ONCE").value


### PR DESCRIPTION
Lately I've seen deprecation warnings from qpoint when running tests; e.g. run py.test on
```
import qpoint
```
and see something like:
```
../../../../code/public/anaconda3/envs/py38/lib/python3.8/site-packages/qpoint/_libqpoint.py:33
  /home/mhasse/code/public/anaconda3/envs/py38/lib/python3.8/site-packages/qpoint/_libqpoint.py:33: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    warri = NDP(np.int, ndim=1, flags=['A','C','W'])

../../../../code/public/anaconda3/envs/py38/lib/python3.8/site-packages/qpoint/_libqpoint.py:36
  /home/mhasse/code/public/anaconda3/envs/py38/lib/python3.8/site-packages/qpoint/_libqpoint.py:36: DeprecationWarning: `np.long` is a deprecated alias for `np.compat.long`. To silence this warning, use `np.compat.long` by itself. In the likely event your code does not need to work on Python 2 you can use the builtin `int` for which `np.compat.long` is itself an alias. Doing this will not modify any behaviour and is safe. When replacing `np.long`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    larr = NDP(np.long, ndim=1, flags=['A','C'])
```

I believe np.int_ is correct in both cases ... that allegedly corresponds to C long, which is what the implicated functions expect.  https://numpy.org/doc/stable/user/basics.types.html

This fixes the warnings, while still compiling, in numpy 1.16, 1.20, and 1.22 (which I happened to have handy...).
