### PR TITLE
More robust array conversion to ctypes

### DIFF
--- a/qpoint/_libqpoint.py
+++ b/qpoint/_libqpoint.py
@@ -138,7 +138,7 @@ class qp_struct_t(ct.Structure):
     """
 
     def __setattr__(self, attr, value):
-        if attr == "_init":
+        if attr == "init":
             return super().__setattr__(attr, QP_STRUCT_INIT if value else 0)
 
         if not hasattr(self, "_fields_dict_"):
@@ -165,7 +165,7 @@ class qp_struct_t(ct.Structure):
 
 class qp_det_t(qp_struct_t):
     _fields_ = [
-        ("_init", ct.c_int),
+        ("init", ct.c_int),
         ("q_off", ct.c_double * 4),
         ("weight", ct.c_double),
         ("gain", ct.c_double),
@@ -185,7 +185,7 @@ qp_det_t_p = ct.POINTER(qp_det_t)
 
 class qp_detarr_t(qp_struct_t):
     _fields_ = [
-        ("_init", ct.c_int),
+        ("init", ct.c_int),
         ("n", ct.c_size_t),
         ("arr_init", ct.c_int),
         ("diff", ct.c_size_t),
@@ -198,7 +198,7 @@ qp_detarr_t_p = ct.POINTER(qp_detarr_t)
 
 class qp_point_t(qp_struct_t):
     _fields_ = [
-        ("_init", ct.c_int),
+        ("init", ct.c_int),
         ("n", ct.c_size_t),
         ("q_bore_init", ct.c_int),
         ("q_bore", ct.POINTER(ct.c_double * 4)),
@@ -239,7 +239,7 @@ proj_modes = {1: QP_PROJ_TEMP, 6: QP_PROJ_POL, 10: QP_PROJ_VPOL}
 
 class qp_map_t(qp_struct_t):
     _fields_ = [
-        ("_init", ct.c_int),
+        ("init", ct.c_int),
         ("partial", ct.c_int),
         ("nside", ct.c_size_t),
         ("npix", ct.c_size_t),

--- a/qpoint/_libqpoint.py
+++ b/qpoint/_libqpoint.py
@@ -37,24 +37,6 @@ QP_DO_ONCE = ct.c_int.in_dll(libqp, "QP_DO_ONCE").value
 QP_DO_NEVER = ct.c_int.in_dll(libqp, "QP_DO_NEVER").value
 
 
-class qp_struct_t(ct.Structure):
-    """
-    ctypes.Structure subclass with automatic numpy array conversion
-    on attribute assignment.
-    """
-
-    def __setattr__(self, attr, value):
-        if not hasattr(self, "_fields_dict_"):
-            super().__setattr__("_fields_dict_", dict(self._fields_))
-        if attr in self._fields_dict_ and isinstance(value, np.ndarray):
-            atype = self._fields_dict_[attr]
-            if issubclass(atype, ct._Pointer):
-                value = value.ctypes.data_as(atype)
-            else:
-                value = np.ctypeslib.as_ctypes(value)
-        return super().__setattr__(attr, value)
-
-
 class qp_state_t(ct.Structure):
     _fields_ = [("update_rate", ct.c_double), ("ctime_last", ct.c_double)]
 
@@ -149,6 +131,34 @@ QP_ARR_MALLOC_1D = 8
 QP_ARR_MALLOC_2D = 16
 
 
+class qp_struct_t(ct.Structure):
+    """
+    ctypes.Structure subclass with automatic numpy array conversion
+    on attribute assignment.
+    """
+
+    def __setattr__(self, attr, value):
+        if not hasattr(self, "_fields_dict_"):
+            super().__setattr__("_fields_dict_", dict(self._fields_))
+        if attr in self._fields_dict_:
+            iattr = f"{attr}_init"
+            ivalue = 0
+            if isinstance(value, ct.Array):
+                ivalue = QP_ARR_INIT_PTR
+            elif isinstance(value, np.ndarray):
+                ivalue = QP_ARR_INIT_PTR
+                atype = self._fields_dict_[attr]
+                if issubclass(atype, ct._Pointer):
+                    value = value.ctypes.data_as(atype)
+                else:
+                    value = np.ctypeslib.as_ctypes(value)
+            if iattr in self._fields_dict_:
+                super().__setattr__(iattr, ivalue)
+            if "init" in self._fields_dict_:
+                super().__setattr__("init", QP_STRUCT_INIT)
+        return super().__setattr__(attr, value)
+
+
 class qp_det_t(qp_struct_t):
     _fields_ = [
         ("init", ct.c_int),
@@ -169,7 +179,7 @@ class qp_det_t(qp_struct_t):
 qp_det_t_p = ct.POINTER(qp_det_t)
 
 
-class qp_detarr_t(ct.Structure):
+class qp_detarr_t(qp_struct_t):
     _fields_ = [
         ("init", ct.c_int),
         ("n", ct.c_size_t),

--- a/qpoint/_libqpoint.py
+++ b/qpoint/_libqpoint.py
@@ -139,7 +139,9 @@ class qp_struct_t(ct.Structure):
 
     def __setattr__(self, attr, value):
         if attr == "init":
-            return super().__setattr__(attr, QP_STRUCT_INIT if value else 0)
+            if isinstance(value, bool):
+                value = QP_STRUCT_INIT if value else 0
+            return super().__setattr__(attr, value)
 
         if not hasattr(self, "_fields_dict_"):
             super().__setattr__("_fields_dict_", dict(self._fields_))

--- a/qpoint/_libqpoint.py
+++ b/qpoint/_libqpoint.py
@@ -138,30 +138,34 @@ class qp_struct_t(ct.Structure):
     """
 
     def __setattr__(self, attr, value):
+        if attr == "_init":
+            return super().__setattr__(attr, QP_STRUCT_INIT if value else 0)
+
         if not hasattr(self, "_fields_dict_"):
             super().__setattr__("_fields_dict_", dict(self._fields_))
-        if attr in self._fields_dict_:
-            iattr = f"{attr}_init"
-            ivalue = 0
-            if isinstance(value, ct.Array):
-                ivalue = QP_ARR_INIT_PTR
-            elif isinstance(value, np.ndarray):
-                ivalue = QP_ARR_INIT_PTR
-                atype = self._fields_dict_[attr]
-                if issubclass(atype, ct._Pointer):
-                    value = value.ctypes.data_as(atype)
-                else:
-                    value = np.ctypeslib.as_ctypes(value)
-            if iattr in self._fields_dict_:
-                super().__setattr__(iattr, ivalue)
-            if "init" in self._fields_dict_:
-                super().__setattr__("init", QP_STRUCT_INIT)
-        return super().__setattr__(attr, value)
+        if attr not in self._fields_dict_:
+            return super().__setattr__(attr, value)
+
+        iattr = f"{attr}_init"
+        ivalue = 0
+        if isinstance(value, ct.Array):
+            ivalue = QP_ARR_INIT_PTR
+        elif isinstance(value, np.ndarray):
+            ivalue = QP_ARR_INIT_PTR
+            atype = self._fields_dict_[attr]
+            if issubclass(atype, ct._Pointer):
+                value = value.ctypes.data_as(atype)
+            else:
+                value = np.ctypeslib.as_ctypes(value)
+        rvalue = super().__setattr__(attr, value)
+        if iattr in self._fields_dict_:
+            super().__setattr__(iattr, ivalue)
+        return rvalue
 
 
 class qp_det_t(qp_struct_t):
     _fields_ = [
-        ("init", ct.c_int),
+        ("_init", ct.c_int),
         ("q_off", ct.c_double * 4),
         ("weight", ct.c_double),
         ("gain", ct.c_double),
@@ -181,7 +185,7 @@ qp_det_t_p = ct.POINTER(qp_det_t)
 
 class qp_detarr_t(qp_struct_t):
     _fields_ = [
-        ("init", ct.c_int),
+        ("_init", ct.c_int),
         ("n", ct.c_size_t),
         ("arr_init", ct.c_int),
         ("diff", ct.c_size_t),
@@ -194,7 +198,7 @@ qp_detarr_t_p = ct.POINTER(qp_detarr_t)
 
 class qp_point_t(qp_struct_t):
     _fields_ = [
-        ("init", ct.c_int),
+        ("_init", ct.c_int),
         ("n", ct.c_size_t),
         ("q_bore_init", ct.c_int),
         ("q_bore", ct.POINTER(ct.c_double * 4)),
@@ -235,7 +239,7 @@ proj_modes = {1: QP_PROJ_TEMP, 6: QP_PROJ_POL, 10: QP_PROJ_VPOL}
 
 class qp_map_t(qp_struct_t):
     _fields_ = [
-        ("init", ct.c_int),
+        ("_init", ct.c_int),
         ("partial", ct.c_int),
         ("nside", ct.c_size_t),
         ("npix", ct.c_size_t),

--- a/qpoint/_libqpoint.py
+++ b/qpoint/_libqpoint.py
@@ -37,6 +37,24 @@ QP_DO_ONCE = ct.c_int.in_dll(libqp, "QP_DO_ONCE").value
 QP_DO_NEVER = ct.c_int.in_dll(libqp, "QP_DO_NEVER").value
 
 
+class qp_struct_t(ct.Structure):
+    """
+    ctypes.Structure subclass with automatic numpy array conversion
+    on attribute assignment.
+    """
+
+    def __setattr__(self, attr, value):
+        if not hasattr(self, "_fields_dict_"):
+            super().__setattr__("_fields_dict_", dict(self._fields_))
+        if attr in self._fields_dict_ and isinstance(value, np.ndarray):
+            atype = self._fields_dict_[attr]
+            if issubclass(atype, ct._Pointer):
+                value = value.ctypes.data_as(atype)
+            else:
+                value = np.ctypeslib.as_ctypes(value)
+        return super().__setattr__(attr, value)
+
+
 class qp_state_t(ct.Structure):
     _fields_ = [("update_rate", ct.c_double), ("ctime_last", ct.c_double)]
 
@@ -131,7 +149,7 @@ QP_ARR_MALLOC_1D = 8
 QP_ARR_MALLOC_2D = 16
 
 
-class qp_det_t(ct.Structure):
+class qp_det_t(qp_struct_t):
     _fields_ = [
         ("init", ct.c_int),
         ("q_off", ct.c_double * 4),
@@ -164,7 +182,7 @@ class qp_detarr_t(ct.Structure):
 qp_detarr_t_p = ct.POINTER(qp_detarr_t)
 
 
-class qp_point_t(ct.Structure):
+class qp_point_t(qp_struct_t):
     _fields_ = [
         ("init", ct.c_int),
         ("n", ct.c_size_t),
@@ -205,7 +223,7 @@ QP_PROJ_VPOL = 3
 proj_modes = {1: QP_PROJ_TEMP, 6: QP_PROJ_POL, 10: QP_PROJ_VPOL}
 
 
-class qp_map_t(ct.Structure):
+class qp_map_t(qp_struct_t):
     _fields_ = [
         ("init", ct.c_int),
         ("partial", ct.c_int),
@@ -237,10 +255,6 @@ def pointer_2d(d):
     return (
         d.__array_interface__["data"][0] + np.arange(d.shape[0]) * d.strides[0]
     ).astype(np.uintp)
-
-
-def as_ctypes(d):
-    return np.ctypeslib.as_ctypes(d)
 
 
 def setargs(fname, arg=None, res=None):

--- a/qpoint/qmap_class.py
+++ b/qpoint/qmap_class.py
@@ -181,9 +181,7 @@ class QMap(QPoint):
         """
         if not hasattr(self, "_source"):
             return False
-        if not self._source.contents.init:
-            return False
-        return True
+        return self._source.contents.init
 
     def init_source(
         self,
@@ -305,6 +303,7 @@ class QMap(QPoint):
         source.proj_mode = 0
         source.proj = None
         source.proj1d = None
+        source.init = True
 
         if partial:
             if qp.qp_init_map_pixhash(self._source, pixels, npix):
@@ -354,9 +353,7 @@ class QMap(QPoint):
         """
         if not hasattr(self, "_dest"):
             return False
-        if not self._dest.contents.init:
-            return False
-        return True
+        return self._dest.contents.init
 
     def init_dest(
         self,
@@ -561,6 +558,7 @@ class QMap(QPoint):
             ret += (proj.squeeze(),)
         dest.vec = None
         dest.proj = None
+        dest.init = True
 
         if partial:
             if qp.qp_init_map_pixhash(self._dest, pixels, npix):
@@ -620,9 +618,7 @@ class QMap(QPoint):
         """
         if not hasattr(self, "_point"):
             return False
-        if not self._point.contents.init:
-            return False
-        return True
+        return self._point.contents.init
 
     def init_point(self, q_bore=None, ctime=None, q_hwp=None):
         """
@@ -656,6 +652,7 @@ class QMap(QPoint):
             point.n = n
             self.depo["q_bore"] = q_bore
             point.q_bore = q_bore
+            point.init = True
 
         if not point.init:
             raise RuntimeError("point not initialized")
@@ -790,11 +787,13 @@ class QMap(QPoint):
                 dets[idx].weights = weights[idx]
             else:
                 dets[idx].weights = None
+            dets[idx].init = True
 
         detarr = lib.qp_detarr_t()
         detarr.n = n
         detarr.arr = dets
         detarr.diff = 0
+        detarr.init = True
 
         if do_diff:
             detarr.diff = 1

--- a/qpoint/qmap_class.py
+++ b/qpoint/qmap_class.py
@@ -260,7 +260,7 @@ class QMap(QPoint):
                 source_map, _ = check_map(source_map, partial=True)
                 source.num_vec = len(source_map)
                 source.vec_mode = lib.get_vec_mode(source_map, pol, vpol)
-                source.vec1d = lib.as_ctypes(source_map.ravel())
+                source.vec1d = source_map.ravel()
                 self.depo["source_map"] = source_map
                 if qp.qp_reshape_map(self._source):
                     raise RuntimeError("Error reshaping source map")
@@ -301,7 +301,7 @@ class QMap(QPoint):
         source.pixhash = None
         source.num_vec = len(source_map)
         source.vec_mode = lib.get_vec_mode(smap, pol, vpol)
-        source.vec1d = lib.as_ctypes(smap.ravel())
+        source.vec1d = smap.ravel()
         source.vec1d_init = lib.QP_ARR_INIT_PTR
         source.vec = None
         source.vec_init = 0
@@ -437,7 +437,7 @@ class QMap(QPoint):
                     vec, _ = check_map(vec, copy=copy, partial=True)
                     dest.num_vec = len(vec)
                     dest.vec_mode = lib.get_vec_mode(vec, pol, vpol)
-                    dest.vec1d = lib.as_ctypes(vec.ravel())
+                    dest.vec1d = vec.ravel()
                     self.depo["vec"] = vec
                     ret += (vec.squeeze(),)
 
@@ -452,7 +452,7 @@ class QMap(QPoint):
                     proj, _ = check_map(proj, copy=copy, partial=True)
                     dest.num_proj = len(proj)
                     dest.proj_mode = lib.get_proj_mode(proj, pol, vpol)
-                    dest.proj1d = lib.as_ctypes(proj.ravel())
+                    dest.proj1d = proj.ravel()
                     self.depo["proj"] = proj
                     ret += (proj.squeeze(),)
 
@@ -561,13 +561,13 @@ class QMap(QPoint):
         if vec is not False:
             dest.num_vec = len(vec)
             dest.vec_mode = lib.get_vec_mode(vec, pol, vpol)
-            dest.vec1d = lib.as_ctypes(vec.ravel())
+            dest.vec1d = vec.ravel()
             dest.vec1d_init = lib.QP_ARR_INIT_PTR
             ret += (vec.squeeze(),)
         if proj is not False:
             dest.num_proj = len(proj)
             dest.proj_mode = lib.get_proj_mode(proj, pol, vpol)
-            dest.proj1d = lib.as_ctypes(proj.ravel())
+            dest.proj1d = proj.ravel()
             dest.proj1d_init = lib.QP_ARR_INIT_PTR
             ret += (proj.squeeze(),)
         dest.vec = None
@@ -669,7 +669,7 @@ class QMap(QPoint):
             n = q_bore.size // 4
             point.n = n
             self.depo["q_bore"] = q_bore
-            point.q_bore = lib.as_ctypes(q_bore)
+            point.q_bore = q_bore
             point.q_bore_init = lib.QP_ARR_INIT_PTR
             point.init = lib.QP_STRUCT_INIT
 
@@ -685,7 +685,7 @@ class QMap(QPoint):
             ctime = lib.check_input("ctime", ctime, shape=(n,))
             self.depo["ctime"] = ctime
             point.ctime_init = lib.QP_ARR_INIT_PTR
-            point.ctime = lib.as_ctypes(ctime)
+            point.ctime = ctime
 
         if q_hwp is False:
             point.q_hwp_init = 0
@@ -694,7 +694,7 @@ class QMap(QPoint):
             q_hwp = lib.check_input("q_hwp", q_hwp, shape=(n, 4), quat=True)
             self.depo["q_hwp"] = q_hwp
             point.q_hwp_init = lib.QP_ARR_INIT_PTR
-            point.q_hwp = lib.as_ctypes(q_hwp)
+            point.q_hwp = q_hwp
 
     def reset_point(self):
         """
@@ -792,26 +792,26 @@ class QMap(QPoint):
         dets = (lib.qp_det_t * n)()
         for idx, (q, w, g, m) in enumerate(zip(q_off, weight, gain, mueller)):
             dets[idx].init = lib.QP_STRUCT_INIT
-            dets[idx].q_off = lib.as_ctypes(q)
+            dets[idx].q_off = q
             dets[idx].weight = w
             dets[idx].gain = g
-            dets[idx].mueller = lib.as_ctypes(m)
+            dets[idx].mueller = m
             if tod is not None:
                 dets[idx].n = ns
                 dets[idx].tod_init = lib.QP_ARR_INIT_PTR
-                dets[idx].tod = lib.as_ctypes(tod[idx])
+                dets[idx].tod = tod[idx]
             else:
                 dets[idx].tod_init = 0
             if flag is not None:
                 dets[idx].n = ns
                 dets[idx].flag_init = lib.QP_ARR_INIT_PTR
-                dets[idx].flag = lib.as_ctypes(flag[idx])
+                dets[idx].flag = flag[idx]
             else:
                 dets[idx].flag_init = 0
             if weights is not None:
                 dets[idx].n = ns
                 dets[idx].weights_init = lib.QP_ARR_INIT_PTR
-                dets[idx].weights = lib.as_ctypes(weights[idx])
+                dets[idx].weights = weights[idx]
 
         detarr = lib.qp_detarr_t()
         detarr.n = n

--- a/qpoint/qmap_class.py
+++ b/qpoint/qmap_class.py
@@ -295,23 +295,16 @@ class QMap(QPoint):
         source.partial = partial
         source.nside = nside
         source.npix = npix
-        source.pixinfo_init = 0
         source.pixinfo = None
-        source.pixhash_init = 0
         source.pixhash = None
         source.num_vec = len(source_map)
         source.vec_mode = lib.get_vec_mode(smap, pol, vpol)
         source.vec1d = smap.ravel()
-        source.vec1d_init = lib.QP_ARR_INIT_PTR
         source.vec = None
-        source.vec_init = 0
         source.num_proj = 0
         source.proj_mode = 0
         source.proj = None
-        source.proj_init = 0
         source.proj1d = None
-        source.proj1d_init = 0
-        source.init = lib.QP_STRUCT_INIT
 
         if partial:
             if qp.qp_init_map_pixhash(self._source, pixels, npix):
@@ -554,27 +547,20 @@ class QMap(QPoint):
         dest.nside = nside
         dest.npix = npix
         dest.partial = partial
-        dest.pixinfo_init = 0
         dest.pixinfo = None
-        dest.pixhash_init = 0
         dest.pixhash = None
         if vec is not False:
             dest.num_vec = len(vec)
             dest.vec_mode = lib.get_vec_mode(vec, pol, vpol)
             dest.vec1d = vec.ravel()
-            dest.vec1d_init = lib.QP_ARR_INIT_PTR
             ret += (vec.squeeze(),)
         if proj is not False:
             dest.num_proj = len(proj)
             dest.proj_mode = lib.get_proj_mode(proj, pol, vpol)
             dest.proj1d = proj.ravel()
-            dest.proj1d_init = lib.QP_ARR_INIT_PTR
             ret += (proj.squeeze(),)
         dest.vec = None
-        dest.vec_init = 0
         dest.proj = None
-        dest.proj_init = 0
-        dest.init = lib.QP_STRUCT_INIT
 
         if partial:
             if qp.qp_init_map_pixhash(self._dest, pixels, npix):
@@ -670,8 +656,6 @@ class QMap(QPoint):
             point.n = n
             self.depo["q_bore"] = q_bore
             point.q_bore = q_bore
-            point.q_bore_init = lib.QP_ARR_INIT_PTR
-            point.init = lib.QP_STRUCT_INIT
 
         if not point.init:
             raise RuntimeError("point not initialized")
@@ -679,21 +663,17 @@ class QMap(QPoint):
         n = point.n
 
         if ctime is False:
-            point.ctime_init = 0
             point.ctime = None
         elif ctime is not None:
             ctime = lib.check_input("ctime", ctime, shape=(n,))
             self.depo["ctime"] = ctime
-            point.ctime_init = lib.QP_ARR_INIT_PTR
             point.ctime = ctime
 
         if q_hwp is False:
-            point.q_hwp_init = 0
             point.q_hwp = None
         elif q_hwp is not None:
             q_hwp = lib.check_input("q_hwp", q_hwp, shape=(n, 4), quat=True)
             self.depo["q_hwp"] = q_hwp
-            point.q_hwp_init = lib.QP_ARR_INIT_PTR
             point.q_hwp = q_hwp
 
     def reset_point(self):
@@ -791,32 +771,28 @@ class QMap(QPoint):
         # populate array
         dets = (lib.qp_det_t * n)()
         for idx, (q, w, g, m) in enumerate(zip(q_off, weight, gain, mueller)):
-            dets[idx].init = lib.QP_STRUCT_INIT
             dets[idx].q_off = q
             dets[idx].weight = w
             dets[idx].gain = g
             dets[idx].mueller = m
             if tod is not None:
                 dets[idx].n = ns
-                dets[idx].tod_init = lib.QP_ARR_INIT_PTR
                 dets[idx].tod = tod[idx]
             else:
-                dets[idx].tod_init = 0
+                dets[idx].tod = None
             if flag is not None:
                 dets[idx].n = ns
-                dets[idx].flag_init = lib.QP_ARR_INIT_PTR
                 dets[idx].flag = flag[idx]
             else:
-                dets[idx].flag_init = 0
+                dets[idx].flag = None
             if weights is not None:
                 dets[idx].n = ns
-                dets[idx].weights_init = lib.QP_ARR_INIT_PTR
                 dets[idx].weights = weights[idx]
+            else:
+                dets[idx].weights = None
 
         detarr = lib.qp_detarr_t()
         detarr.n = n
-        detarr.init = lib.QP_STRUCT_INIT
-        detarr.arr_init = lib.QP_ARR_INIT_PTR
         detarr.arr = dets
         detarr.diff = 0
 

--- a/qpoint/qmap_class.py
+++ b/qpoint/qmap_class.py
@@ -181,7 +181,9 @@ class QMap(QPoint):
         """
         if not hasattr(self, "_source"):
             return False
-        return self._source.contents.init
+        if not self._source.contents.init:
+            return False
+        return True
 
     def init_source(
         self,
@@ -353,7 +355,9 @@ class QMap(QPoint):
         """
         if not hasattr(self, "_dest"):
             return False
-        return self._dest.contents.init
+        if not self._dest.contents.init:
+            return False
+        return True
 
     def init_dest(
         self,
@@ -618,7 +622,9 @@ class QMap(QPoint):
         """
         if not hasattr(self, "_point"):
             return False
-        return self._point.contents.init
+        if not self._point.contents.init:
+            return False
+        return True
 
     def init_point(self, q_bore=None, ctime=None, q_hwp=None):
         """


### PR DESCRIPTION
This PR is designed to avoid a TypeError with newer versions of python/numpy on some machines.  This change ensures that structures that expect pointer-type attributes are provided the correct ctypes object.